### PR TITLE
fix: download image on IE11

### DIFF
--- a/.playground/index.html
+++ b/.playground/index.html
@@ -21,7 +21,7 @@
         left: 0px;
       }
       .chart {
-        background: black;
+        background: white;
         display: inline-block;
         position: relative;
         width: 900px;

--- a/.playground/playgroud.tsx
+++ b/.playground/playgroud.tsx
@@ -7,8 +7,9 @@ import {
   Position,
   ScaleType,
   HistogramBarSeries,
-  DARK_THEME,
   Settings,
+  LIGHT_THEME,
+  niceTimeFormatter,
 } from '../src';
 import { KIBANA_METRICS } from '../src/utils/data_samples/test_dataset_kibana';
 export class Playground extends React.Component {
@@ -17,55 +18,41 @@ export class Playground extends React.Component {
     if (!this.chartRef.current) {
       return;
     }
-
-    const image = this.chartRef.current.getPNGSnapshot();
-    if (!image) {
+    const snapshot = this.chartRef.current.getPNGSnapshot({
+      backgroundColor: 'red',
+      pixelRatio: 1,
+    });
+    if (!snapshot) {
       return;
     }
-
-    const canvas = document.createElement('canvas');
-
-    // determine size of the background chart
-    const chart = document.querySelector('.echChart');
-    if (!chart) {
-      return;
+    const fileName = 'chart.png';
+    switch (snapshot.browser) {
+      case 'IE11':
+        return navigator.msSaveBlob(snapshot.blobOrDataUrl, fileName);
+      default:
+        const link = document.createElement('a');
+        link.download = fileName;
+        link.href = snapshot.blobOrDataUrl;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
     }
-    const width = chart.clientWidth;
-    const height = chart.clientHeight;
-
-    canvas.setAttribute('width', width.toString());
-    canvas.setAttribute('height', height.toString());
-    const context = canvas.getContext('2d');
-
-    const img = new Image();
-    img.src = image;
-
-    img.onload = function() {
-      if (!context) {
-        return;
-      }
-      context.fillRect(0, 0, width, height);
-      context.drawImage(img, 0, 0);
-
-      const link = document.createElement('a');
-      link.download = 'image.png';
-      link.href = canvas.toDataURL();
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-    };
   };
   render() {
-    const data = KIBANA_METRICS.metrics.kibana_os_load[0].data.slice(0, 5);
+    const data = KIBANA_METRICS.metrics.kibana_os_load[0].data.slice(0, 100);
 
     return (
       <>
         <button onClick={this.onSnapshot}>Snapshot</button>
         <div className="chart">
           <Chart ref={this.chartRef}>
-            <Settings theme={DARK_THEME} rotation={180} showLegend={true} />
-            <Axis id={getAxisId('x')} position={Position.Bottom} />
-            <Axis id={getAxisId('y')} position={Position.Left} />
+            <Settings theme={LIGHT_THEME} showLegend={true} />
+            <Axis
+              id={getAxisId('time')}
+              position={Position.Bottom}
+              tickFormat={niceTimeFormatter([data[0][0], data[data.length - 1][0]])}
+            />
+            <Axis id={getAxisId('count')} position={Position.Left} />
 
             <HistogramBarSeries
               id={getSpecId('series bars chart')}

--- a/src/components/chart.tsx
+++ b/src/components/chart.tsx
@@ -16,6 +16,7 @@ import { Position } from '../chart_types/xy_chart/utils/specs';
 import { CursorEvent } from '../specs/settings';
 import { ChartSize, getChartSize } from '../utils/chart_size';
 import { Stage } from 'react-konva';
+import Konva from 'konva';
 
 interface ChartProps {
   /** The type of rendered
@@ -95,11 +96,53 @@ export class Chart extends React.Component<ChartProps, ChartState> {
     }
   }
 
-  getPNGSnapshot(): string | null {
+  getPNGSnapshot(
+    options = {
+      backgroundColor: 'transparent',
+      pixelRatio: 1,
+    },
+  ): {
+    blobOrDataUrl: any;
+    browser: 'IE11' | 'other';
+  } | null {
     if (!this.chartStageRef.current) {
       return null;
     }
-    return this.chartStageRef.current.getStage().toDataURL({});
+    const stage = this.chartStageRef.current.getStage().clone();
+    const width = stage.getWidth();
+    const height = stage.getHeight();
+    const backgroundLayer = new Konva.Layer();
+    const backgroundRect = new Konva.Rect({
+      fill: options.backgroundColor,
+      x: 0,
+      y: 0,
+      width,
+      height,
+    });
+
+    backgroundLayer.add(backgroundRect);
+    stage.add(backgroundLayer);
+    backgroundLayer.moveToBottom();
+    stage.draw();
+    const canvasStage = stage.toCanvas({
+      width,
+      height,
+      callback: () => {},
+    });
+    // @ts-ignore
+    if (canvasStage.msToBlob) {
+      // @ts-ignore
+      const blobOrDataUrl = canvasStage.msToBlob();
+      return {
+        blobOrDataUrl,
+        browser: 'IE11',
+      };
+    } else {
+      return {
+        blobOrDataUrl: stage.toDataURL({ pixelRatio: options.pixelRatio }),
+        browser: 'other',
+      };
+    }
   }
 
   getChartContainerRef = () => {


### PR DESCRIPTION
## Summary

I've added the support for IE11 + the background image

TO DO:
- [ ] check consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [ ] Proper documentation or storybook story was added for features that require explanation or tutorials
- [ ] Unit tests if possible

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] Any consumer-facing exports were added to `src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [x] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Proper documentation or storybook story was added for features that require explanation or tutorials
- [ ] Unit tests were updated or added to match the most common scenarios
- [x] Each commit follows the [convention](https://github.com/elastic/elastic-charts/blob/master/CONTRIBUTING.md)
